### PR TITLE
Add "analyzer_token_limit", limits stream for hit_source anlayzer

### DIFF
--- a/experimental-highlighter-core/pom.xml
+++ b/experimental-highlighter-core/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.wikimedia.search.highlighter</groupId>
     <artifactId>experimental</artifactId>
-    <version>1.7.1-SNAPSHOT</version>
+    <version>1.7.2-SNAPSHOT</version>
   </parent>
   <artifactId>experimental-highlighter-core</artifactId>
   <packaging>jar</packaging>

--- a/experimental-highlighter-elasticsearch-plugin/pom.xml
+++ b/experimental-highlighter-elasticsearch-plugin/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.wikimedia.search.highlighter</groupId>
     <artifactId>experimental</artifactId>
-    <version>1.7.1-SNAPSHOT</version>
+    <version>1.7.2-SNAPSHOT</version>
   </parent>
   <artifactId>experimental-highlighter-elasticsearch-plugin</artifactId>
   <packaging>jar</packaging>

--- a/experimental-highlighter-elasticsearch-plugin/src/main/java/org/elasticsearch/search/highlight/FieldWrapper.java
+++ b/experimental-highlighter-elasticsearch-plugin/src/main/java/org/elasticsearch/search/highlight/FieldWrapper.java
@@ -283,6 +283,14 @@ public class FieldWrapper {
         return buildTokenStreamHitEnum(analyzer);
     }
 
+    private int getAnalyzerTokenLimit() {
+        Integer analyzerTokenLimit = (Integer) executionContext.getOption("analyzer_token_limit");
+        if (analyzerTokenLimit == null) {
+            analyzerTokenLimit = TokenStreamHitEnum.DEFAULT_TOKEN_LIMIT;
+        }
+        return analyzerTokenLimit;
+    }
+
     private HitEnum buildTokenStreamHitEnum(final Analyzer analyzer) throws IOException {
         List<String> fieldValues = getFieldValues();
         switch (fieldValues.size()) {
@@ -329,7 +337,7 @@ public class FieldWrapper {
                     "If analyzing to find hits each matched field must have a unique analyzer.", e);
         }
         this.tokenStream = tokenStream;
-        return new TokenStreamHitEnum(tokenStream, getQueryWeigher(true), getCorpusWeigher(true), weigher);
+        return new TokenStreamHitEnum(tokenStream, getQueryWeigher(true), getCorpusWeigher(true), weigher, getAnalyzerTokenLimit());
     }
 
     private TermWeigher<BytesRef> getQueryWeigher(boolean mightWeighTermsMultipleTimes) {

--- a/experimental-highlighter-elasticsearch-plugin/src/test/java/org/wikimedia/highlighter/experimental/elasticsearch/integration/OptionsTest.java
+++ b/experimental-highlighter-elasticsearch-plugin/src/test/java/org/wikimedia/highlighter/experimental/elasticsearch/integration/OptionsTest.java
@@ -517,4 +517,20 @@ public class OptionsTest extends AbstractExperimentalHighlighterIntegrationTestB
         }
     }
 
+    @Test
+    public void truncateValues() throws IOException {
+        buildIndex(false, true, 1);
+        indexTestData("one two");
+
+        Map<String, Object> options = new HashMap<String, Object>();
+        options.put("analyzer_token_limit", 1);
+        options.put("hit_source", "analyze");
+
+        SearchRequestBuilder search = testSearch(termQuery("test", "two"))
+                .addHighlightedField(new HighlightBuilder.Field("test").noMatchSize(20).options(options));
+
+        SearchResponse response = search.get();
+        assertHighlight(response, 0, "test", 0, equalTo("one two"));
+    }
+
 }

--- a/experimental-highlighter-lucene/pom.xml
+++ b/experimental-highlighter-lucene/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.wikimedia.search.highlighter</groupId>
     <artifactId>experimental</artifactId>
-    <version>1.7.1-SNAPSHOT</version>
+    <version>1.7.2-SNAPSHOT</version>
   </parent>
   <artifactId>experimental-highlighter-lucene</artifactId>
   <packaging>jar</packaging>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
   <groupId>org.wikimedia.search.highlighter</groupId>
   <artifactId>experimental</artifactId>
-  <version>1.7.1-SNAPSHOT</version>
+  <version>1.7.2-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <modules>


### PR DESCRIPTION
This is in an attempt to limit damage when we hit a large document
that isn't using postings or fvh. We simply close off the stream
when we hit this limit. I'm assuming the TokenStream is lazy in
for analysis so we can avoid analyzing the whole source if we hit
the token limit before the end.

An alternative we can use if this doesn't help with performance is
just to truncate the `source` directly which will surely avoid
analysis although then potentially introduces artefacts on the
truncation boundary, unless we do some more intelligent boundary
detection, but then I guess we're back to analysis!